### PR TITLE
Fix CSS to be not WebKit-specific

### DIFF
--- a/static/css/base.css
+++ b/static/css/base.css
@@ -9,12 +9,14 @@ body{
 		position:relative;
 		display: flex;
 		-webkit-flex-direction: column;
+		flex-direction: column;
 		color: #555;
 		}
 
 #horiz_cols {
 		display: flex;
 		-webkit-flex-direction: row;
+		flex-direction: row;
 }
 
 #bg {
@@ -36,6 +38,7 @@ body{
 	background-size: cover;
 	background-image: url(/static/images/big-crowd.jpg);
 	-webkit-filter: blur(4px);
+	filter: blur(4px);
 	z-index: -1;
 }
 


### PR DESCRIPTION
WebKit is the new IE6. Who knew?

The login page in Firefox:

![lyar-firefox](https://cloud.githubusercontent.com/assets/128854/6888795/1a3746a4-d6d4-11e4-9c2f-e98238106a49.png)